### PR TITLE
Create alias for Parameters

### DIFF
--- a/reportwidgets/Changelog.php
+++ b/reportwidgets/Changelog.php
@@ -5,7 +5,7 @@ use Markdown;
 use BackendAuth;
 use Backend\Classes\ReportWidgetBase;
 use October\Rain\Network\Http;
-use System\Models\Parameters;
+use System\Models\Parameter as Parameters;
 use ApplicationException;
 use SystemException;
 use Exception;


### PR DESCRIPTION
`System\Models\Parameters` doesn't exist, it's singular. Dashboard was throwing errors when trying use widget.